### PR TITLE
Add support for creating data models from markdown strings

### DIFF
--- a/mdmodels/create.py
+++ b/mdmodels/create.py
@@ -84,6 +84,7 @@ BASIC_TYPE_ELEMENTS = {
 
 def build_module(
     path: pathlib.Path | str | None = None,
+    content: str | None = None,
     data_model: RSDataModel | None = None,
     ignore_attributes: list[str] = [],
 ) -> Library:
@@ -92,6 +93,7 @@ def build_module(
 
     Args:
         path (pathlib.Path | str): Path to the markdown file.
+        content (str | None): The content of the markdown file.
         data_model (RSDataModel | None): The data model. If None, it will be initialized from the path.
 
     Returns:
@@ -106,6 +108,8 @@ def build_module(
         dm = data_model
     elif path:
         dm = init_data_model(path)
+    elif content:
+        dm = RSDataModel.from_markdown_string(content)
     else:
         raise ValueError("Either 'path' or 'data_model' must be provided")
 

--- a/mdmodels/datamodel.py
+++ b/mdmodels/datamodel.py
@@ -200,6 +200,29 @@ class DataModel(
         return build_module(path, ignore_attributes=ignore_attributes)
 
     @classmethod
+    def from_markdown_string(
+        cls,
+        content: str,
+        ignore_attributes: list[str] = [],
+    ) -> Library:
+        """
+        Create a data model from a markdown string.
+
+        Args:
+            content (str): The content of the markdown file.
+            ignore_attributes (list[str]): A list of attributes to ignore.
+
+        Returns:
+            Library: A dotted dict containing the generated modules
+
+        Raises:
+            ValueError: If the content is not a valid markdown string.
+        """
+        from .create import build_module
+
+        return build_module(content=content, ignore_attributes=ignore_attributes)
+
+    @classmethod
     def from_json_schema(
         cls,
         schema: Path | str,

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -22,3 +22,15 @@ class TestCreate:
 
         for part in expected_parts:
             assert part in library, f"Part {part} not found in library"
+
+    def test_create_from_string(self):
+        """
+        Test the creation of a data model library from a markdown string.
+        """
+        library = build_module(content=open("./tests/fixtures/model.md").read())
+
+        # Assert
+        expected_parts = ["Test", "Nested", "Ontology"]
+
+        for part in expected_parts:
+            assert part in library, f"Part {part} not found in library"


### PR DESCRIPTION
This pull request adds support for creating data model libraries directly from markdown strings, in addition to existing file-based workflows. The main changes introduce a new method for initializing models from string content, update relevant function signatures and documentation, and add a unit test to verify the new functionality.

### Feature: Support for Markdown String Input

* Added a `content` parameter to the `build_module` function in `mdmodels/create.py`, allowing data models to be built from a markdown string instead of a file path.
* Updated the logic in `build_module` to handle the new `content` parameter and initialize the data model from a markdown string when provided.

### API & Documentation Updates

* Updated the docstring for `build_module` to document the new `content` argument.
* Added the `from_markdown_string` class method to `RSDataModel` in `mdmodels/datamodel.py` for creating a data model directly from markdown content.

### Testing

* Added a new unit test `test_create_from_string` in `tests/unit/test_create.py` to verify that building a library from a markdown string works as expected.Introduces the ability to build a data model library directly from a markdown string via the new 'content' argument in build_module and the DataModel.from_markdown_string class method. Includes a unit test to verify creation from string content.